### PR TITLE
NextJS Support

### DIFF
--- a/lib/field/types.ts
+++ b/lib/field/types.ts
@@ -1,4 +1,4 @@
-import { ZodTypeAny } from "zod";
+import type { ZodTypeAny } from "zod";
 import { FormInstance } from "../form/types";
 
 type ValidationFunction<T, F> =

--- a/lib/field/use-field-like-sync.ts
+++ b/lib/field/use-field-like-sync.ts
@@ -1,7 +1,8 @@
-import { MutableRefObject, useContext, useLayoutEffect } from "react";
+import { MutableRefObject, useContext } from "react";
 import { FieldInstance } from "./types";
 import { FieldArrayInstance } from "../field-array";
 import { FormContext } from "../form";
+import useIsomorphicLayoutEffect from "../utils/use-isomorphic-layout-effect";
 
 export interface UseFieldLikeSyncProps<
   T,
@@ -42,7 +43,7 @@ export const useFieldLikeSync = <
   /**
    * Add mutable ref to formFieldsRef
    */
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     mutableRef.current.props = props;
     const newMutable = mutableRef.current;
     formFieldsRef.current.push(newMutable);
@@ -56,38 +57,38 @@ export const useFieldLikeSync = <
   /**
    * Sync the values with the mutable ref
    */
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     mutableRef.current.value = value;
   }, [mutableRef, value]);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     mutableRef.current.errors = errors;
   }, [errors, mutableRef]);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     mutableRef.current.isDirty = isDirty;
   }, [isDirty, mutableRef]);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     mutableRef.current.isValid = isValid;
   }, [isValid, mutableRef]);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     mutableRef.current.isTouched = isTouched;
   }, [isTouched, mutableRef]);
 
   /**
    * Recompute form errors when field errors change
    */
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     recomputeErrors();
   }, [errors, recomputeErrors]);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     recomputeIsTouched();
   }, [isTouched, recomputeIsTouched]);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     recomputeIsDirty();
   }, [isDirty, recomputeIsDirty]);
 };

--- a/lib/field/use-field-like.ts
+++ b/lib/field/use-field-like.ts
@@ -2,7 +2,6 @@ import {
   MutableRefObject,
   useCallback,
   useContext,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -12,6 +11,7 @@ import { FormContext } from "../form";
 import { FieldInstance } from "./types";
 import { FieldArrayInstance } from "../field-array";
 import { getValidationError, stringToPath, validate } from "../utils";
+import useIsomorphicLayoutEffect from "../utils/use-isomorphic-layout-effect";
 
 interface UseListenToListenToArrayProps<T> {
   listenTo: string[] | undefined;
@@ -25,7 +25,7 @@ export function useListenToListenToArray<T>({
 }: UseListenToListenToArrayProps<T>) {
   const formContext = useContext(FormContext);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!listenTo || listenTo.length === 0) return;
 
     function onChangeListener() {

--- a/lib/field/use-field-like.ts
+++ b/lib/field/use-field-like.ts
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { ZodError } from "zod";
+import type { ZodError } from "zod";
 import { FormContext } from "../form";
 import { FieldInstance } from "./types";
 import { FieldArrayInstance } from "../field-array";

--- a/lib/form/form.tsx
+++ b/lib/form/form.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { ZodError } from "zod";
+import type { ZodError } from "zod";
 import { fillPath, getValidationError, stringToPath, validate } from "../utils";
 import { useFormlike } from "./use-formlike";
 import { FieldInstance } from "../field";

--- a/lib/utils/is-browser.ts
+++ b/lib/utils/is-browser.ts
@@ -1,0 +1,1 @@
+export const isBrowser = typeof window !== "undefined";

--- a/lib/utils/use-isomorphic-layout-effect.ts
+++ b/lib/utils/use-isomorphic-layout-effect.ts
@@ -1,0 +1,6 @@
+import { useEffect, useLayoutEffect } from "react";
+import { isBrowser } from "./is-browser";
+
+const useIsomorphicLayoutEffect = isBrowser ? useLayoutEffect : useEffect;
+
+export default useIsomorphicLayoutEffect;

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -1,4 +1,4 @@
-import { ZodError, ZodTypeAny } from "zod";
+import type { ZodError, ZodTypeAny } from "zod";
 import { FormInstance } from "../form/types";
 
 export function validate<T>(
@@ -6,15 +6,20 @@ export function validate<T>(
   form: FormInstance<T>,
   validator: ZodTypeAny | ((val: T, form: FormInstance<T>) => Promise<boolean>)
 ) {
-  if (validator instanceof Function) {
-    return validator(val, form);
-  } else {
+  const isZodValidator = (validator: any): validator is ZodTypeAny => {
+    return validator instanceof Object && validator.parseAsync;
+  };
+  if (isZodValidator(validator)) {
     return validator.parseAsync(val);
   }
+  return validator(val, form);
 }
 
 export function getValidationError(error: ZodError | string) {
-  if (error instanceof ZodError) {
+  const isZodError = (error: any): error is ZodError => {
+    return error instanceof Object && error.errors;
+  };
+  if (isZodError(error)) {
     return error.errors.map((error) => error.message);
   } else {
     return [error];


### PR DESCRIPTION
This PR fixes #17 by:

- Introducing `useIsomorphicLayoutEffect` instead of `useLayoutEffect`
- Removing Zod logic imports that were throwing errors when using a Zod validator
