### PR TITLE
Add missing props to FieldInstanceProps and FieldArrayInstanceProps types

### DIFF
--- a/lib/field-array/field-array.tsx
+++ b/lib/field-array/field-array.tsx
@@ -7,9 +7,8 @@ import React, {
   useMemo,
   useRef,
 } from "react";
-import { FieldInstanceBaseProps } from "../field/types";
 import { FieldArrayContext } from "./context";
-import { FieldArrayInstance } from "./types";
+import { FieldArrayInstance, FieldArrayInstanceProps } from "./types";
 import {
   useFieldLike,
   useListenToListenToArray,
@@ -17,10 +16,8 @@ import {
 import { useFieldLikeSync } from "../field/use-field-like-sync";
 
 export interface FieldArrayRenderProps<T = any, F = any>
-  extends FieldInstanceBaseProps<T, F> {
+  extends FieldArrayInstanceProps<T, F> {
   children: (props: FieldArrayInstance<T, F>) => JSX.Element;
-  initialValue?: T[];
-  memoChild?: any[];
 }
 
 function FieldArrayComp<T = any, F = any>(

--- a/lib/field-array/types.ts
+++ b/lib/field-array/types.ts
@@ -9,10 +9,16 @@ export interface FieldArrayHelpers<T> {
   swap: (indexA: number, indexB: number) => void;
 }
 
+export interface FieldArrayInstanceProps<T = any, F = any>
+  extends FieldInstanceBaseProps<T, F> {
+  initialValue?: T[];
+  memoChild?: any[];
+}
+
 export interface FieldArrayInstance<T = any, F = any>
   extends FieldArrayHelpers<T> {
   _normalizedDotName: string;
-  props: FieldInstanceBaseProps<T, F>;
+  props: FieldArrayInstanceProps<T, F>;
   value: T[];
   setValue: (index: number, value: T) => void;
   setErrors: (errors: string[]) => void;

--- a/lib/field/field.tsx
+++ b/lib/field/field.tsx
@@ -16,8 +16,6 @@ import { FormContext } from "../form";
 export interface FieldRenderProps<T = any, F = any>
   extends FieldInstanceProps<T, F> {
   children: (props: FieldInstance<T, F>) => JSX.Element;
-  initialValue?: T;
-  memoChild?: any[];
 }
 
 function FieldComp<T = any, F = any>(

--- a/lib/field/types.ts
+++ b/lib/field/types.ts
@@ -16,6 +16,8 @@ export interface FieldInstanceProps<T = any, F = any>
   extends FieldInstanceBaseProps<T, F> {
   onBlurValidate?: ValidationFunction<T, F>;
   onMountValidate?: ValidationFunction<T, F>;
+  initialValue?: T;
+  memoChild?: any[];
 }
 
 export interface FieldInstance<T = any, F = any> {


### PR DESCRIPTION
This PR adds missing `initialValue` and `memoChild` TS types for `FieldInstanceProps` and `FieldArrayInstannceProps` types.

This is a bug fix and is the first step towards implementing both a temporary workaround for #62 as well as a long-term fix for that feature request