### PR TITLE
feat: add ability to set FieldArray array value

### DIFF
--- a/docs/reference/array.md
+++ b/docs/reference/array.md
@@ -30,21 +30,22 @@ The `ArrayField` component takes the following props:
 
 ### _Interface_ `FieldArrayInstance`
 
-| Property       | Type                                       | Description                                                  |
-| -------------- | ------------------------------------------ | ------------------------------------------------------------ |
-| `value`        | `T`                                        | `T` is the type of the Field that's passed to the `<Field<T>>` component. |
-| `setValue`     | `(val: T) => void`                         | A function useful to change the value of a field             |
-| `errors`       | `string[]`                                 | The list of errors currently applied to the field.           |
-| `setErrors`    | `(errors: string[]) => void`               | A way to set the errors present on the field.                |
-| `isValid`      | `boolean`                                  | A helper property to check if `errors` is an empty array.    |
+| Property       | Type                                       | Description                                                                           |
+|----------------|--------------------------------------------|---------------------------------------------------------------------------------------|
+| `value`        | `T`                                        | `T` is the type of the Field that's passed to the `<Field<T>>` component.             |
+| `setValue`     | `(val: T) => void`                         | A function useful to change the value of a field                                      |
+| `setValues`    | `(val: T[]) => void`                       | A function useful to change the value of the form array.                              |
+| `errors`       | `string[]`                                 | The list of errors currently applied to the field.                                    |
+| `setErrors`    | `(errors: string[]) => void`               | A way to set the errors present on the field.                                         |
+| `isValid`      | `boolean`                                  | A helper property to check if `errors` is an empty array.                             |
 | `isTouched`    | `boolean`                                  | A boolean to say if the field has been focused and blurred, regardless of user input. |
-| `setIsTouched` | `(val: boolean) => void`                   |                                                              |
-| `isDirty`      | `boolean`                                  | A boolean to say if the field has had any kind of user input. |
-| `setIsDirty`   | `(val: boolean) => void`                   |                                                              |
-| `props`        | [`ArrayFieldProps`](#array-field-props)    | The properties originally passed to a field from the component. |
-| `add`          | `(val: T) => void`                         | A helper utility to add an item to the form array.           |
-| `remove`       | `(index: number) => void`                  | A helper utility to remove an item via an index from the form array. |
-| `insert`       | `(index: number, val: T) => void`          | A helper utility to insert an item at the index to the form array. |
-| `move`         | `(from: number, to: number) => void`       | A helper utility to move an item from one index to another in the form array. |
-| `replace`      | `(index: number, val: T) => void`          | A helper utility to replace an item at an index on the form array. |
-| `swap`         | `(indexA: number, indexB: number) => void` | A helper utility to swap two items on the form array.        |
+| `setIsTouched` | `(val: boolean) => void`                   |                                                                                       |
+| `isDirty`      | `boolean`                                  | A boolean to say if the field has had any kind of user input.                         |
+| `setIsDirty`   | `(val: boolean) => void`                   |                                                                                       |
+| `props`        | [`ArrayFieldProps`](#array-field-props)    | The properties originally passed to a field from the component.                       |
+| `add`          | `(val: T) => void`                         | A helper utility to add an item to the form array.                                    |
+| `remove`       | `(index: number) => void`                  | A helper utility to remove an item via an index from the form array.                  |
+| `insert`       | `(index: number, val: T) => void`          | A helper utility to insert an item at the index to the form array.                    |
+| `move`         | `(from: number, to: number) => void`       | A helper utility to move an item from one index to another in the form array.         |
+| `replace`      | `(index: number, val: T) => void`          | A helper utility to replace an item at an index on the form array.                    |
+| `swap`         | `(indexA: number, indexB: number) => void` | A helper utility to swap two items on the form array.                                 |

--- a/lib/field-array/context.ts
+++ b/lib/field-array/context.ts
@@ -5,6 +5,7 @@ import { FieldArrayInstance } from "./types";
 export const initialFieldArrayContext = {
   value: [],
   setValue: () => {},
+  setValues: () => {},
   props: {
     name: "",
   },

--- a/lib/field-array/field-array.spec.tsx
+++ b/lib/field-array/field-array.spec.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { Field, FieldArray, FieldArrayItem, Form } from "houseform";
 import { z } from "zod";
 
@@ -260,6 +260,35 @@ test("field array should run onSubmit validation", async () => {
   await user.click(getByText("Submit"));
 
   expect(getByText("Should have at least three items")).toBeInTheDocument();
+});
+
+test("field array setValues should set the field array values", async () => {
+  const { getByText, queryByText } = render(
+    <Form>
+      {() => (
+        <FieldArray<number> name={"people"} initialValue={[1]}>
+          {({ value, setValues }) => (
+            <>
+              {value.map((num) => (
+                <p key={num}>Num {num}</p>
+              ))}
+              <button onClick={() => setValues([1, 2, 3])}>Set value</button>
+            </>
+          )}
+        </FieldArray>
+      )}
+    </Form>
+  );
+
+  expect(getByText("Num 1")).toBeInTheDocument();
+  expect(queryByText("Num 2")).not.toBeInTheDocument();
+  expect(queryByText("Num 3")).not.toBeInTheDocument();
+
+  fireEvent.click(getByText("Set value"));
+
+  expect(getByText("Num 1")).toBeInTheDocument();
+  expect(getByText("Num 2")).toBeInTheDocument();
+  expect(getByText("Num 3")).toBeInTheDocument();
 });
 
 test("field array should work with listenTo as the subject", async () => {

--- a/lib/field-array/field-array.tsx
+++ b/lib/field-array/field-array.tsx
@@ -147,6 +147,7 @@ function FieldArrayComp<T = any, F = any>(
       isDirty,
       setIsTouched,
       isTouched,
+      setValues,
     };
   }, [
     value,
@@ -166,6 +167,7 @@ function FieldArrayComp<T = any, F = any>(
     isDirty,
     setIsTouched,
     isTouched,
+    setValues,
   ]);
 
   const mutableRef = useRef<FieldArrayInstance<T, F>>(fieldArrayInstance);

--- a/lib/field-array/types.ts
+++ b/lib/field-array/types.ts
@@ -20,6 +20,7 @@ export interface FieldArrayInstance<T = any, F = any>
   _normalizedDotName: string;
   props: FieldArrayInstanceProps<T, F>;
   value: T[];
+  setValues: (value: T[]) => void;
   setValue: (index: number, value: T) => void;
   setErrors: (errors: string[]) => void;
   errors: string[];


### PR DESCRIPTION
This PR adds the API of `setValues` for a `FieldArray`, which does two things for us:

1) Allows us to set a form's array (important for #62)
2) Gives us an easy field to hook into to differentiate the TS typings for `FieldInstance` and `FieldArrayInstance`