### PR TITLE
feat: add manual validation

### DIFF
--- a/docs/reference/array.md
+++ b/docs/reference/array.md
@@ -30,22 +30,23 @@ The `ArrayField` component takes the following props:
 
 ### _Interface_ `FieldArrayInstance`
 
-| Property       | Type                                       | Description                                                                           |
-|----------------|--------------------------------------------|---------------------------------------------------------------------------------------|
-| `value`        | `T`                                        | `T` is the type of the Field that's passed to the `<Field<T>>` component.             |
-| `setValue`     | `(val: T) => void`                         | A function useful to change the value of a field                                      |
-| `setValues`    | `(val: T[]) => void`                       | A function useful to change the value of the form array.                              |
-| `errors`       | `string[]`                                 | The list of errors currently applied to the field.                                    |
-| `setErrors`    | `(errors: string[]) => void`               | A way to set the errors present on the field.                                         |
-| `isValid`      | `boolean`                                  | A helper property to check if `errors` is an empty array.                             |
-| `isTouched`    | `boolean`                                  | A boolean to say if the field has been focused and blurred, regardless of user input. |
-| `setIsTouched` | `(val: boolean) => void`                   |                                                                                       |
-| `isDirty`      | `boolean`                                  | A boolean to say if the field has had any kind of user input.                         |
-| `setIsDirty`   | `(val: boolean) => void`                   |                                                                                       |
-| `props`        | [`ArrayFieldProps`](#array-field-props)    | The properties originally passed to a field from the component.                       |
-| `add`          | `(val: T) => void`                         | A helper utility to add an item to the form array.                                    |
-| `remove`       | `(index: number) => void`                  | A helper utility to remove an item via an index from the form array.                  |
-| `insert`       | `(index: number, val: T) => void`          | A helper utility to insert an item at the index to the form array.                    |
-| `move`         | `(from: number, to: number) => void`       | A helper utility to move an item from one index to another in the form array.         |
-| `replace`      | `(index: number, val: T) => void`          | A helper utility to replace an item at an index on the form array.                    |
-| `swap`         | `(indexA: number, indexB: number) => void` | A helper utility to swap two items on the form array.                                 |
+| Property       | Type                                                         | Description                                                  |
+| -------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `value`        | `T`                                                          | `T` is the type of the Field that's passed to the `<Field<T>>` component. |
+| `setValue`     | `(val: T) => void`                                           | A function useful to change the value of a field             |
+| `setValues`    | `(val: T[]) => void`                                         | A function useful to change the value of the form array.     |
+| `errors`       | `string[]`                                                   | The list of errors currently applied to the field.           |
+| `setErrors`    | `(errors: string[]) => void`                                 | A way to set the errors present on the field.                |
+| `isValid`      | `boolean`                                                    | A helper property to check if `errors` is an empty array.    |
+| `isTouched`    | `boolean`                                                    | A boolean to say if the field has been focused and blurred, regardless of user input. |
+| `setIsTouched` | `(val: boolean) => void`                                     |                                                              |
+| `isDirty`      | `boolean`                                                    | A boolean to say if the field has had any kind of user input. |
+| `setIsDirty`   | `(val: boolean) => void`                                     |                                                              |
+| `props`        | [`ArrayFieldProps`](#array-field-props)                      | The properties originally passed to a field from the component. |
+| `add`          | `(val: T) => void`                                           | A helper utility to add an item to the form array.           |
+| `remove`       | `(index: number) => void`                                    | A helper utility to remove an item via an index from the form array. |
+| `insert`       | `(index: number, val: T) => void`                            | A helper utility to insert an item at the index to the form array. |
+| `move`         | `(from: number, to: number) => void`                         | A helper utility to move an item from one index to another in the form array. |
+| `replace`      | `(index: number, val: T) => void`                            | A helper utility to replace an item at an index on the form array. |
+| `swap`         | `(indexA: number, indexB: number) => void`                   | A helper utility to swap two items on the form array.        |
+| `validate`     | `(rule: 'onChangeValidate' \| 'onSubmitValidate' \| 'onMountValidate' \| 'onBlurValidate') => void` | A method of running manual change detection on a field arrary. |

--- a/docs/reference/field.md
+++ b/docs/reference/field.md
@@ -26,16 +26,17 @@ A field is the primitive for every input that you'd like to display to the user.
 
 ### _Interface_ `FieldInstance`
 
-| Property       | Type                         | Description                                                  |
-| -------------- | ---------------------------- | ------------------------------------------------------------ |
-| `value`        | `T`                          | `T` is the type of the Field that's passed to the `<Field<T>>` component. |
-| `setValue`     | `(val: T) => void`           | A function useful to change the value of a field             |
-| `onBlur`       | `() => void`                 | A function expected to be passed to the `onBlur` element property. |
-| `errors`       | `string[]`                   | The list of errors currently applied to the field.           |
-| `setErrors`    | `(errors: string[]) => void` | A way to set the errors present on the field.                |
-| `isValid`      | `boolean`                    | A helper property to check if `errors` is an empty array.    |
-| `isTouched`    | `boolean`                    | A boolean to say if the field has been focused and blurred, regardless of user input. |
-| `setIsTouched` | `(val: boolean) => void`     |                                                              |
-| `isDirty`      | `boolean`                    | A boolean to say if the field has had any kind of user input. |
-| `setIsDirty`   | `(val: boolean) => void`     |                                                              |
-| `props`        | [`FieldProps`](#field-props) | The properties originally passed to a field from the component. |
+| Property       | Type                                                         | Description                                                  |
+| -------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `value`        | `T`                                                          | `T` is the type of the Field that's passed to the `<Field<T>>` component. |
+| `setValue`     | `(val: T) => void`                                           | A function useful to change the value of a field             |
+| `onBlur`       | `() => void`                                                 | A function expected to be passed to the `onBlur` element property. |
+| `errors`       | `string[]`                                                   | The list of errors currently applied to the field.           |
+| `setErrors`    | `(errors: string[]) => void`                                 | A way to set the errors present on the field.                |
+| `isValid`      | `boolean`                                                    | A helper property to check if `errors` is an empty array.    |
+| `isTouched`    | `boolean`                                                    | A boolean to say if the field has been focused and blurred, regardless of user input. |
+| `setIsTouched` | `(val: boolean) => void`                                     |                                                              |
+| `isDirty`      | `boolean`                                                    | A boolean to say if the field has had any kind of user input. |
+| `setIsDirty`   | `(val: boolean) => void`                                     |                                                              |
+| `props`        | [`FieldProps`](#field-props)                                 | The properties originally passed to a field from the component. |
+| `validate`     | `(rule: 'onChangeValidate' \| 'onSubmitValidate' \| 'onMountValidate' \|  'onBlurValidate') => void` | A function used to manually run change detection on a field instance. |

--- a/lib/field-array-item/field-array-item.tsx
+++ b/lib/field-array-item/field-array-item.tsx
@@ -42,6 +42,7 @@ export function FieldArrayItemComp<T = any, F = any>(
     setIsTouched,
     isDirty,
     setIsDirty,
+    validate,
   } = useFieldLike<T, F, FieldInstance<T, F>>({
     props,
     initialValue: "" as T,
@@ -159,6 +160,7 @@ export function FieldArrayItemComp<T = any, F = any>(
       setIsDirty,
       setErrors,
       setIsTouched,
+      validate,
     };
   }, [
     setValue,
@@ -173,6 +175,7 @@ export function FieldArrayItemComp<T = any, F = any>(
     setIsDirty,
     setErrors,
     setIsTouched,
+    validate,
   ]);
 
   const mutableRef = useRef<FieldInstance<T>>(fieldArrayInstance);

--- a/lib/field-array/context.ts
+++ b/lib/field-array/context.ts
@@ -23,6 +23,7 @@ export const initialFieldArrayContext = {
   move: () => {},
   swap: () => {},
   replace: () => {},
+  validate: () => {},
 } as FieldArrayInstance;
 /* c8 ignore stop */
 

--- a/lib/field-array/field-array.spec.tsx
+++ b/lib/field-array/field-array.spec.tsx
@@ -375,3 +375,5 @@ test.todo("Should track all subfield errors");
 test.todo("Should track all subfield isTouched");
 
 test.todo("Should track all subfield isDirty");
+
+test.todo("Manual validation should work");

--- a/lib/field-array/field-array.tsx
+++ b/lib/field-array/field-array.tsx
@@ -39,6 +39,7 @@ function FieldArrayComp<T = any, F = any>(
     valueRef,
     setIsDirty,
     setIsTouched,
+    validate,
   } = useFieldLike<T, F, FieldArrayInstance<T, F>>({
     props,
     initialValue: [] as T[],
@@ -148,6 +149,7 @@ function FieldArrayComp<T = any, F = any>(
       setIsTouched,
       isTouched,
       setValues,
+      validate,
     };
   }, [
     value,
@@ -168,6 +170,7 @@ function FieldArrayComp<T = any, F = any>(
     setIsTouched,
     isTouched,
     setValues,
+    validate,
   ]);
 
   const mutableRef = useRef<FieldArrayInstance<T, F>>(fieldArrayInstance);

--- a/lib/field-array/types.ts
+++ b/lib/field-array/types.ts
@@ -29,4 +29,7 @@ export interface FieldArrayInstance<T = any, F = any>
   setIsDirty: (val: boolean) => void;
   isDirty: boolean;
   isTouched: boolean;
+  validate: (
+    validationType: "onChangeValidate" | "onBlurValidate" | "onMountValidate"
+  ) => void;
 }

--- a/lib/field/field.spec.tsx
+++ b/lib/field/field.spec.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { fireEvent, render, waitFor } from "@testing-library/react";
-import { Field, FieldInstance, Form } from "houseform";
+import { Field, FieldInstance, Form, FormInstance } from "houseform";
 
 import { z } from "zod";
 import { useEffect, useRef, useState } from "react";
@@ -784,4 +784,47 @@ test("Field should only run listeners when value changes", async () => {
   await waitFor(() =>
     expect(getAllByText("Must be at least three")).toHaveLength(2)
   );
+});
+
+test("Field should manually validate", async () => {
+  const Comp = () => {
+    const formRef = useRef<FormInstance>(null);
+
+    const runValidate = () => {
+      formRef.current?.getFieldValue("test")!.validate("onChangeValidate");
+    };
+
+    return (
+      <div>
+        <Form ref={formRef}>
+          {() => (
+            <Field
+              name={"test"}
+              initialValue={"Te"}
+              onChangeValidate={z.string().min(3, "Must be at least three")}
+            >
+              {({ errors, value }) => {
+                return (
+                  <div>
+                    <p>Value: {value}</p>
+                    {errors.map((error) => (
+                      <p key={error}>{error}</p>
+                    ))}
+                  </div>
+                );
+              }}
+            </Field>
+          )}
+        </Form>
+        <button onClick={runValidate}>Validate</button>
+      </div>
+    );
+  };
+
+  const { getByText, queryByText, findByText } = render(<Comp />);
+
+  expect(getByText("Value: Te")).toBeInTheDocument();
+  expect(queryByText("Must be at least three")).not.toBeInTheDocument();
+  await user.click(getByText("Validate"));
+  expect(await findByText("Must be at least three")).toBeInTheDocument();
 });

--- a/lib/field/field.spec.tsx
+++ b/lib/field/field.spec.tsx
@@ -828,3 +828,46 @@ test("Field should manually validate", async () => {
   await user.click(getByText("Validate"));
   expect(await findByText("Must be at least three")).toBeInTheDocument();
 });
+
+test("Field should not throw error if manually validate against non-used validation type", async () => {
+  const Comp = () => {
+    const formRef = useRef<FormInstance>(null);
+
+    const runValidate = () => {
+      formRef.current?.getFieldValue("test")!.validate("onBlurValidate");
+    };
+
+    return (
+      <div>
+        <Form ref={formRef}>
+          {() => (
+            <Field
+              name={"test"}
+              initialValue={"Te"}
+              onChangeValidate={z.string().min(3, "Must be at least three")}
+            >
+              {({ errors, value }) => {
+                return (
+                  <div>
+                    <p>Value: {value}</p>
+                    {errors.map((error) => (
+                      <p key={error}>{error}</p>
+                    ))}
+                  </div>
+                );
+              }}
+            </Field>
+          )}
+        </Form>
+        <button onClick={runValidate}>Validate</button>
+      </div>
+    );
+  };
+
+  const { getByText, queryByText, findByText } = render(<Comp />);
+
+  expect(getByText("Value: Te")).toBeInTheDocument();
+  expect(queryByText("Must be at least three")).not.toBeInTheDocument();
+  await user.click(getByText("Validate"));
+  expect(queryByText("Must be at least three")).not.toBeInTheDocument();
+});

--- a/lib/field/field.tsx
+++ b/lib/field/field.tsx
@@ -38,6 +38,7 @@ function FieldComp<T = any, F = any>(
     runFieldValidation,
     valueRef,
     _normalizedDotName,
+    validate,
   } = useFieldLike<T, F, FieldInstance<T, F>>({
     props,
     initialValue: "" as T,
@@ -84,6 +85,7 @@ function FieldComp<T = any, F = any>(
       isValid,
       onBlur,
       _normalizedDotName,
+      validate,
     };
   }, [
     props,
@@ -98,6 +100,7 @@ function FieldComp<T = any, F = any>(
     isValid,
     onBlur,
     _normalizedDotName,
+    validate,
   ]);
 
   const mutableRef = useRef<FieldInstance<T>>(fieldInstance);

--- a/lib/field/types.ts
+++ b/lib/field/types.ts
@@ -33,4 +33,7 @@ export interface FieldInstance<T = any, F = any> {
   isTouched: boolean;
   setIsDirty: (val: boolean) => void;
   isDirty: boolean;
+  validate: (
+    validationType: "onChangeValidate" | "onBlurValidate" | "onMountValidate"
+  ) => void;
 }

--- a/lib/field/use-field-like.ts
+++ b/lib/field/use-field-like.ts
@@ -215,6 +215,13 @@ export const useFieldLike = <
     return errors.length === 0;
   }, [errors]);
 
+  const exportedValidate = useCallback(
+    (validationFnName: Parameters<typeof runFieldValidation>[0]) => {
+      runFieldValidation(validationFnName, valueRef.current);
+    },
+    [runFieldValidation, valueRef]
+  );
+
   return {
     value,
     setErrors,
@@ -227,6 +234,7 @@ export const useFieldLike = <
     isValid,
     runFieldValidation,
     valueRef,
+    validate: exportedValidate,
     _normalizedDotName,
   };
 };


### PR DESCRIPTION
This PR adds the ability to manually run validation against a field instance.

It does this by implementing the following API:

```tsx
const formRef = useRef(null);

// ...
const nameField = formRef.current?.getFieldValue("name");
await nameField?.validate('onSubmitValidate'); // returns validation promise
nameField.errors; // string[]
```

- [x] Functionality
- [x] Tests
- [x] Docs
    - [x] Reference docs
    - [x] ~~Guide docs~~ Not needed for this feature

Closes #38